### PR TITLE
support alibaba cloud oss blobstore

### DIFF
--- a/client/handlers.go
+++ b/client/handlers.go
@@ -17,6 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"regexp"
+	"github.com/cloudfoundry/bosh-s3cli/config"
 )
 
 const (
@@ -122,8 +124,20 @@ func (v2 *signer) Sign() error {
 		return err
 	}
 	host, canonicalPath := parsedURL.Host, parsedURL.Path
+
+	// Host can not be parsed successfully results from v2.Request.URL has a non-empty Opaque.
+	if len(host) < 1 {
+		host = v2.Request.URL.Host
+	}
+
 	v2.Request.Header["Host"] = []string{host}
 	v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
+
+	// Alibaba Cloud OSS date's formate must be http.TimeFormat
+	if regexp.MustCompile(config.AlicloudHostRegex).MatchString(host) {
+		log.Printf("Using Alicloud host: %#v", host)
+		v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(http.TimeFormat)}
+	}
 
 	for k, v := range headers {
 		k = strings.ToLower(k)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -388,6 +388,35 @@ var _ = Describe("BlobstoreClient configuration", func() {
 			})
 		})
 	})
+
+	Describe("returning the alicloud region", func() {
+		Context("when host is provided", func() {
+			It("returns a region id in the public `host`", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "oss-some-region.aliyuncs.com"}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.Region).To(Equal("some-region"))
+			})
+			It("returns a region id in the private `host`", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "oss-some-region-internal.aliyuncs.com"}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.Region).To(Equal("some-region"))
+			})
+			It("returns a empty string if `host` is empty", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": ""}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.S3Endpoint()).To(Equal(""))
+			})
+		})
+	})
 })
 
 type explodingReader struct{}


### PR DESCRIPTION
The PR add some codes to support oss blobstore. For oss API, it requires a different data format with s3 manager. In addition, in order to avoid conflicting with other service, oss blobstore requires a host address and uses it to get region.