### PR TITLE
Add ForcePathStyle to support OSS new request

### DIFF
--- a/client/handlers.go
+++ b/client/handlers.go
@@ -133,9 +133,10 @@ func (v2 *signer) Sign() error {
 	v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
 
 	// Alibaba Cloud OSS date's formate must be http.TimeFormat
-	// URL Host's format is host or host:port
-	if config.Provider(strings.Split(host, ":")[0]) == "alicloud" {
+	// Alibaba Cloud OSS uses virtual hosted and the URL Host's format is <bucket-name>.host or <bucket-name>host:port
+	if config.Provider(strings.Join(strings.Split(strings.Split(host, ":")[0], ".")[1:], ".")) == "alicloud" {
 		v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(http.TimeFormat)}
+		canonicalPath = fmt.Sprintf("/%s%s", strings.Split(host, ".")[0], canonicalPath)
 	}
 
 	for k, v := range headers {

--- a/client/sdk.go
+++ b/client/sdk.go
@@ -22,7 +22,7 @@ func NewSDK(c config.S3Cli) (*s3.S3, error) {
 
 	s3Config := aws.NewConfig().
 		WithLogLevel(aws.LogOff).
-		WithS3ForcePathStyle(true).
+		WithS3ForcePathStyle(c.ForcePathStyle).
 		WithDisableSSL(!c.UseSSL).
 		WithHTTPClient(httpClient)
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 )
 
 // The S3Cli represents configuration for the s3cli
@@ -25,6 +26,7 @@ type S3Cli struct {
 	SSEKMSKeyID          string `json:"sse_kms_key_id"`
 	UseV2SigningMethod   bool
 	MultipartUpload      bool
+	ForcePathStyle       bool
 }
 
 // EmptyRegion is required to allow us to use the AWS SDK against S3 compatible blobstores which do not have
@@ -69,8 +71,9 @@ func NewFromReader(reader io.Reader) (S3Cli, error) {
 	}
 
 	c := S3Cli{
-		SSLVerifyPeer: true,
-		UseSSL:        true,
+		SSLVerifyPeer:  true,
+		UseSSL:         true,
+		ForcePathStyle: true,
 	}
 
 	err = json.Unmarshal(bytes, &c)
@@ -152,9 +155,11 @@ func (c *S3Cli) configureAWS() {
 }
 
 func (c *S3Cli) configureAlicloud() {
-	c.MultipartUpload = false
+	c.MultipartUpload = true
 	c.configureDefaultSigningMethod()
+	c.ForcePathStyle = false
 
+	c.Host = strings.Split(c.Host, ":")[0]
 	if c.Region == "" {
 		c.Region = AlicloudHostToRegion(c.Host)
 	}


### PR DESCRIPTION
This PR aims to support putting and getting alibaba cloud oss object.

At present, Alibaba Cloud OSS request host uses virtual host style, but previous s3cli only supports path style and it will happen a "SecondLevelDomainForbidden" error.  So, this PR adds a new field 'ForcePathStyle' to support it.