### PR TITLE
Add ForcePathStyle to support OSS new request

### DIFF
--- a/client/handlers.go
+++ b/client/handlers.go
@@ -133,9 +133,10 @@ func (v2 *signer) Sign() error {
 	v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
 
 	// Alibaba Cloud OSS date's formate must be http.TimeFormat
-	// URL Host's format is host or host:port
-	if config.Provider(strings.Split(host, ":")[0]) == "alicloud" {
+	// Alibaba Cloud OSS uses virtual hosted and the URL Host's format is <bucket-name>.host or <bucket-name>.host:port
+	if config.Provider(strings.Join(strings.Split(strings.Split(host, ":")[0], ".")[1:], ".")) == "alicloud" {
 		v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(http.TimeFormat)}
+		canonicalPath = fmt.Sprintf("/%s%s", strings.Split(host, ".")[0], canonicalPath)
 	}
 
 	for k, v := range headers {

--- a/client/sdk.go
+++ b/client/sdk.go
@@ -22,7 +22,7 @@ func NewSDK(c config.S3Cli) (*s3.S3, error) {
 
 	s3Config := aws.NewConfig().
 		WithLogLevel(aws.LogOff).
-		WithS3ForcePathStyle(true).
+		WithS3ForcePathStyle(c.ForcePathStyle).
 		WithDisableSSL(!c.UseSSL).
 		WithHTTPClient(httpClient)
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 )
 
 // The S3Cli represents configuration for the s3cli
@@ -25,6 +26,7 @@ type S3Cli struct {
 	SSEKMSKeyID          string `json:"sse_kms_key_id"`
 	UseV2SigningMethod   bool
 	MultipartUpload      bool
+	ForcePathStyle       bool
 }
 
 // EmptyRegion is required to allow us to use the AWS SDK against S3 compatible blobstores which do not have
@@ -69,8 +71,9 @@ func NewFromReader(reader io.Reader) (S3Cli, error) {
 	}
 
 	c := S3Cli{
-		SSLVerifyPeer: true,
-		UseSSL:        true,
+		SSLVerifyPeer:  true,
+		UseSSL:         true,
+		ForcePathStyle: true,
 	}
 
 	err = json.Unmarshal(bytes, &c)
@@ -152,9 +155,11 @@ func (c *S3Cli) configureAWS() {
 }
 
 func (c *S3Cli) configureAlicloud() {
-	c.MultipartUpload = false
+	c.MultipartUpload = true
 	c.configureDefaultSigningMethod()
+	c.ForcePathStyle = false
 
+	c.Host = strings.Split(c.Host, ":")[0]
 	if c.Region == "" {
 		c.Region = AlicloudHostToRegion(c.Host)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -250,6 +250,64 @@ var _ = Describe("BlobstoreClient configuration", func() {
 			})
 		})
 
+		Describe("configing force path style", func() {
+			It("when Alibaba Cloud provider", func() {
+				configBytes := []byte(`{
+					"access_key_id":      "id",
+					"secret_access_key":  "key",
+					"bucket_name":        "some-bucket",
+					"host":               "oss-some-region.aliyuncs.com"
+				}`)
+
+				configReader := bytes.NewReader(configBytes)
+				s3CliConfig, err := config.NewFromReader(configReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s3CliConfig.ForcePathStyle).To(BeFalse())
+			})
+
+			It("when AWS provider", func() {
+				configBytes := []byte(`{
+					"access_key_id":      "id",
+					"secret_access_key":  "key",
+					"bucket_name":        "some-bucket",
+					"host": 	      "s3.amazonaws.com"
+				}`)
+
+				configReader := bytes.NewReader(configBytes)
+				s3CliConfig, err := config.NewFromReader(configReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s3CliConfig.ForcePathStyle).To(BeTrue())
+			})
+
+			It("when Google provider", func() {
+				configBytes := []byte(`{
+					"access_key_id":      "id",
+					"secret_access_key":  "key",
+					"bucket_name":        "some-bucket",
+					"host": 	      "storage.googleapis.com"
+				}`)
+
+				configReader := bytes.NewReader(configBytes)
+				s3CliConfig, err := config.NewFromReader(configReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s3CliConfig.ForcePathStyle).To(BeTrue())
+			})
+
+			It("when Default provider", func() {
+				configBytes := []byte(`{
+					"access_key_id":      "id",
+					"secret_access_key":  "key",
+					"bucket_name":        "some-bucket",
+					"host": 	      "storage.googleapis.com"
+				}`)
+
+				configReader := bytes.NewReader(configBytes)
+				s3CliConfig, err := config.NewFromReader(configReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s3CliConfig.ForcePathStyle).To(BeTrue())
+			})
+		})
+
 		Context("when the configuration file cannot be read", func() {
 			It("returns an error", func() {
 				f := explodingReader{}
@@ -438,6 +496,7 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				c, err := config.NewFromReader(dummyJSONReader)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(c.S3Endpoint()).To(Equal("oss-some-region.aliyuncs.com:443"))
+				Expect(c.Host).To(Equal("oss-some-region.aliyuncs.com"))
 			})
 			It("returns a empty string URI if `host` is empty", func() {
 				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "", "port": 443}`)
@@ -446,6 +505,7 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				c, err := config.NewFromReader(dummyJSONReader)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(c.S3Endpoint()).To(Equal(""))
+				Expect(c.Host).To(Equal(""))
 			})
 		})
 
@@ -457,6 +517,7 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				c, err := config.NewFromReader(dummyJSONReader)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(c.S3Endpoint()).To(Equal("oss-some-region.aliyuncs.com"))
+				Expect(c.Host).To(Equal("oss-some-region.aliyuncs.com"))
 			})
 			It("returns a empty string URI if `host` is empty", func() {
 				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": ""}`)
@@ -466,6 +527,17 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(c.S3Endpoint()).To(Equal(""))
 			})
+		})
+	})
+
+	Describe("checking the alibaba cloud MultipartUpload", func() {
+		emptyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "oss-some-region.aliyuncs.com"}`)
+		emptyJSONReader := bytes.NewReader(emptyJSONBytes)
+
+		It("defaults to support multipart uploading", func() {
+			c, err := config.NewFromReader(emptyJSONReader)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.MultipartUpload).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This PR aims to support putting and getting alibaba cloud oss object.

At present, Alibaba Cloud OSS request host uses virtual host style, but previous s3cli only supports path style and it will happen a "SecondLevelDomainForbidden" error. So, this PR adds a new field 'ForcePathStyle' to support it.