### PR TITLE
enable to choose "multipart_upload" as true or false

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Given a JSON config file (`config.json`)...
   "use_ssl":                <bool> (optional),
   "signature_version":      "<string> (optional)",
   "server_side_encryption": "<string> (optional)",
-  "sse_kms_key_id":         "<string> (optional)"
+  "sse_kms_key_id":         "<string> (optional)",
   "multipart_upload":       <bool> (optional - default: true)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Given a JSON config file (`config.json`)...
   "signature_version":      "<string> (optional)",
   "server_side_encryption": "<string> (optional)",
   "sse_kms_key_id":         "<string> (optional)"
+  "multipart_upload":       <bool> (optional - default: true)
 }
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,8 +24,8 @@ type S3Cli struct {
 	SignatureVersion     int    `json:"signature_version,string"`
 	ServerSideEncryption string `json:"server_side_encryption"`
 	SSEKMSKeyID          string `json:"sse_kms_key_id"`
+	MultipartUpload      bool `json:"multipart_upload"`
 	UseV2SigningMethod   bool
-	MultipartUpload      bool
 	HostStyle            bool
 }
 
@@ -73,6 +73,7 @@ func NewFromReader(reader io.Reader) (S3Cli, error) {
 	c := S3Cli{
 		SSLVerifyPeer:  true,
 		UseSSL:         true,
+		MultipartUpload: true,
 	}
 
 	err = json.Unmarshal(bytes, &c)
@@ -170,7 +171,6 @@ func (c *S3Cli) configureGoogle() {
 }
 
 func (c *S3Cli) configureDefault() {
-	c.MultipartUpload = true
 	c.configureDefaultSigningMethod()
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,6 +111,26 @@ var _ = Describe("BlobstoreClient configuration", func() {
 					Expect(c.Region).To(Equal("us-east-1"))
 				})
 			})
+
+			Context("when MultipartUpload have been set", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "some-host", "region": "some-region", "multipart_upload": false}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+				It("sets MultipartUpload to user-specified values", func() {
+					c, err := config.NewFromReader(dummyJSONReader)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(c.MultipartUpload).To(BeFalse())
+				})
+			})
+
+			Context("when MultipartUpload have not been set", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "some-host", "region": "some-region"}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+				It("default MultipartUpload to true", func() {
+					c, err := config.NewFromReader(dummyJSONReader)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(c.MultipartUpload).To(BeTrue())
+				})
+			})
 		})
 
 		Describe("when bucket is not specified", func() {


### PR DESCRIPTION
I enable to choose "multipart_upload" as `true` or `false`.
Users who use object storage which does not support multipart upload as blobstore will be helpful.

fix https://github.com/cloudfoundry/bosh-cli/issues/253