### PR TITLE
Swift signed urls must not end with \n

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -110,8 +110,7 @@ var _ = Describe("S3CompatibleClient", func() {
 				urlRegexp =
 					"https://host-name/v1/swift_account/some-bucket/test-object-id" +
 						`\?temp_url_sig=([a-f0-9]+)` +
-						`&temp_url_expires=([0-9]+)` +
-						"\n"
+						`&temp_url_expires=([0-9]+)`
 			})
 
 			Context("when the action is GET", func() {

--- a/client/openstack_swift_client.go
+++ b/client/openstack_swift_client.go
@@ -37,7 +37,7 @@ func (c *openstackSwiftS3Client) signedURL(action string, objectID string, expir
 	h.Write([]byte(hmacBody))
 	signature := hex.EncodeToString(h.Sum(nil))
 
-	url := fmt.Sprintf("https://%s%s?temp_url_sig=%s&temp_url_expires=%d\n", c.s3cliConfig.Host, path, signature, expires)
+	url := fmt.Sprintf("https://%s%s?temp_url_sig=%s&temp_url_expires=%d", c.s3cliConfig.Host, path, signature, expires)
 
 	return url, nil
 }


### PR DESCRIPTION
The refactoring PR #38 added a trailing `\n` to swift blobstore signed urls.
When using that in the director it fails with errors like:

Compiling package postgres-11: Fetching package postgres-11: Fetching package blob : Failed to download blob: Creating Get Request: parse "https://objectstore-3.abcd/v1/AUTH_1234/bosh1234/1234-5678?temp_url_sig=1234&temp_url_expires=1234\n": net/url: invalid control character in URL
